### PR TITLE
fix voting in kickvote command

### DIFF
--- a/lib/minecraft/commands.rb
+++ b/lib/minecraft/commands.rb
@@ -284,8 +284,8 @@ module Minecraft
     #   kickvote("basicxman")
     # @note ops: none
     def kickvote(user, target_user = nil)
-      return @server.puts "say No user #{target_user} exists." unless @users.include? target_user
       return vote(user) if target_user.nil?
+      return @server.puts "say No user #{target_user} exists." unless @users.include? target_user
       unless submit_vote(user, target_user)
         @userkickvotes[target_user] = {
           :tally => kick_influence(user),

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -172,6 +172,16 @@ eof
     assert_match "kick Ian_zers", output
   end
 
+  sandbox_test "should vote for a running kickvote if no target is given" do
+    ext :ops => ["basicxman"], :hops => ["mike_n_7"], :users => ["blizzard4U", "Ian_zers"]
+    call "basicxman kickvote blizzard4U"
+    assert_equal 3, @ext.userkickvotes["blizzard4U"][:tally]
+
+    call "Ian_zers kickvote"
+    assert_equal 4, @ext.userkickvotes["blizzard4U"][:tally]
+    assert_equal "blizzard4U", @ext.last_kick_vote
+  end
+
   # Timer test.
   sandbox_test "should not add a timer if the item does not exist" do
     ext :hops => ["basicxman"]


### PR DESCRIPTION
The command erroneously first checked if target_user was a valid user
and then checked it for being nil, instead of doing it the other way
around.
