### PR TITLE
fix printtimer command in case a user has no timers

### DIFF
--- a/lib/minecraft/commands.rb
+++ b/lib/minecraft/commands.rb
@@ -585,7 +585,7 @@ module Minecraft
     #   printtimer("basicxman")
     # @note ops: hop
     def printtimer(user)
-      unless @timers.has_key? user || @timers[user].length == 0
+      if not @timers.has_key? user || @timers[user].length == 0
         @server.puts "say No timers have been added for #{user}."
         return
       end


### PR DESCRIPTION
The check was broken for the case that a user exists in the @timers
table but has no timers.
